### PR TITLE
Bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/full_ci_cd_workflow.yml
+++ b/.github/workflows/full_ci_cd_workflow.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: [ "3.12", "3.13", "3.14" ]
     container: python:${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -30,7 +30,7 @@ jobs:
         run: |
           coverage run -m unittest
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -41,18 +41,18 @@ jobs:
     needs: testing_job
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -65,18 +65,18 @@ jobs:
     needs: testing_job
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/pr_testing_only.yml
+++ b/.github/workflows/pr_testing_only.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: [ "3.12", "3.13", "3.14" ]
     container: python:${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `docker/setup-qemu-action` v3 → v4
- `docker/setup-buildx-action` v3 → v4
- `docker/login-action` v3 → v4
- `docker/build-push-action` v6 → v7
- `codecov/codecov-action` v4 → v6

`northflank/deploy-to-northflank` stays at v1 (still latest major).

Follow-up to #217 — that PR shipped the Python + CDN bumps but couldn't include the workflow files due to a missing `workflow` token scope. Token has since been re-scoped.

## Test plan
- [ ] PR CI (`pr_testing_only.yml`) runs green on 3.12 / 3.13 / 3.14
- [ ] On merge, the full CI/CD workflow (`full_ci_cd_workflow.yml`) builds multi-arch Docker image and deploys to Northflank as before

https://claude.ai/code/session_016o4kN9NYmyv3d6sFBnW8a3

---
_Generated by [Claude Code](https://claude.ai/code/session_016o4kN9NYmyv3d6sFBnW8a3)_